### PR TITLE
chore: fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,16 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --all-extras --dev
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
 
       - name: Run ruff check
         run: uv run ruff check .
@@ -35,36 +37,28 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        django-version: ['4.2', '5.0', '5.1']
-        wagtail-version: ['5.2', '6.2', '6.3', '6.4']
+        django-version: ['4.2', '5.1', '5.2']
+        wagtail-version: ['6.4', '7.0', '7.2']
         exclude:
-          # Django 5.0+ requires Python 3.10+
-          - django-version: '5.0'
-            python-version: '3.9'
-          - django-version: '5.1'
-            python-version: '3.9'
-          # Wagtail 6.0+ requires Django 4.2+
-          - wagtail-version: '6.2'
-            django-version: '4.1'
-          - wagtail-version: '6.3'
-            django-version: '4.1'
-          - wagtail-version: '6.4'
-            django-version: '4.1'
+          # Django 5.2 requires Python 3.11+
+          - python-version: '3.10'
+            django-version: '5.2'
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
 
       - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras --dev
+          uv venv
+          uv pip install -e ".[dev]"
           uv pip install "django~=${{ matrix.django-version }}.0" "wagtail~=${{ matrix.wagtail-version }}.0"
 
       - name: Run tests
@@ -78,14 +72,19 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install build twine
 
       - name: Build package
-        run: uv build
+        run: uv run python -m build
 
       - name: Check package
         run: uv run twine check dist/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,14 +99,13 @@ tox -l
 
 ### Django Versions
 - **4.2** (LTS - Long Term Support until April 2026)
-- **5.0**
 - **5.1**
+- **5.2**
 
 ### Wagtail Versions
-- **5.2** (LTS - Long Term Support)
-- **6.2**
-- **6.3**
-- **6.4** (latest)
+- **6.4**
+- **7.0**
+- **7.2** (latest)
 
 ### Code Style
 


### PR DESCRIPTION
## Summary
- Fix CI workflow to work without uv.lock (library project)
- Match wagtail-reusable-blocks CI style
- Update supported version matrix

## Changes
- Remove `enable-cache: true` from setup-uv (causes error without uv.lock)
- Use `actions/setup-python` instead of `uv python install`
- Use `uv venv` + `uv pip install` instead of `uv sync`
- Update matrix: Django 4.2/5.1/5.2, Wagtail 6.4/7.0/7.2
- Update CONTRIBUTING.md to match

## Test plan
- [x] CI should pass after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)